### PR TITLE
Remove noexcept specification on defaulted members 

### DIFF
--- a/doc/Doxyfile
+++ b/doc/Doxyfile
@@ -900,7 +900,7 @@ EXCLUDE_PATTERNS       =
 # Note that the wildcards are matched against the file with absolute path, so to
 # exclude all test directories use the pattern */test/*
 
-EXCLUDE_SYMBOLS        = impl
+EXCLUDE_SYMBOLS        =
 
 # The EXAMPLE_PATH tag can be used to specify one or more files or directories
 # that contain example code fragments that are included (see the \include

--- a/include/claws/box.hpp
+++ b/include/claws/box.hpp
@@ -27,11 +27,11 @@ namespace claws
     /// @{
 
     /// Primitive is default initialised. (IE worth 0, or nullptr etc.)
-    constexpr box() noexcept = default;
-    constexpr box(box const &) noexcept = default;
-    constexpr box(box &&) noexcept = default;
-    constexpr box &operator=(box const &) noexcept = default;
-    constexpr box &operator=(box &&) noexcept = default;
+    constexpr box() = default;
+    constexpr box(box const &) = default;
+    constexpr box(box &&) = default;
+    constexpr box &operator=(box const &) = default;
+    constexpr box &operator=(box &&) = default;
 
     constexpr box(type &&value) noexcept
       : value{std::move(value)}
@@ -42,7 +42,7 @@ namespace claws
     {}
     /// @}
 
-    ~box() noexcept = default;
+    ~box() = default;
 
     /// \name User defined conversions
     /// All declared `noexcept` and `constexpr`.

--- a/include/claws/handle_types.hpp
+++ b/include/claws/handle_types.hpp
@@ -148,7 +148,7 @@ namespace claws
     ///
     /// \brief Default construction. Handle is empty.
     ///
-    constexpr handle<type, deleter_type>() noexcept(std::is_nothrow_constructible<type>() && std::is_nothrow_constructible<deleter_type>()) = default;
+    constexpr handle<type, deleter_type>() = default;
 
     ///
     /// @name Deleted copy contructors

--- a/include/claws/iterator_util.hpp
+++ b/include/claws/iterator_util.hpp
@@ -142,12 +142,11 @@ namespace claws
       , _func(func)
     {}
 
-    constexpr container_view() noexcept(std::is_nothrow_default_constructible_v<it_type> &&std::is_nothrow_default_constructible_v<end_type>
-                                          &&std::is_nothrow_default_constructible_v<func_type>) = default;
-    container_view(container_view const &) noexcept(constructors_are_noexcept) = default;
-    container_view(container_view &&) noexcept(constructors_are_noexcept) = default;
-    container_view &operator=(container_view const &) noexcept(constructors_are_noexcept) = default;
-    container_view &operator=(container_view &&) noexcept(constructors_are_noexcept) = default;
+    constexpr container_view() = default;
+    container_view(container_view const &) = default;
+    container_view(container_view &&) = default;
+    container_view &operator=(container_view const &) = default;
+    container_view &operator=(container_view &&) = default;
     /// @}
 
     /// \name iterators to the view
@@ -184,11 +183,11 @@ namespace claws
       : t(t)
     {}
 
-    constexpr same_val_iterator() noexcept(std::is_nothrow_default_constructible<T>()) = default;
-    constexpr same_val_iterator(same_val_iterator const &) noexcept(std::is_nothrow_copy_constructible<T>()) = default;
-    constexpr same_val_iterator(same_val_iterator &&) noexcept(std::is_nothrow_move_constructible<T>()) = default;
-    constexpr same_val_iterator &operator=(same_val_iterator const &) noexcept(std::is_nothrow_copy_constructible<T>()) = default;
-    constexpr same_val_iterator &operator=(same_val_iterator &&) noexcept(std::is_nothrow_move_constructible<T>()) = default;
+    constexpr same_val_iterator() = default;
+    constexpr same_val_iterator(same_val_iterator const &) = default;
+    constexpr same_val_iterator(same_val_iterator &&) = default;
+    constexpr same_val_iterator &operator=(same_val_iterator const &) = default;
+    constexpr same_val_iterator &operator=(same_val_iterator &&) = default;
 
     constexpr auto &operator*() const noexcept
     {

--- a/include/claws/self_iterator.hpp
+++ b/include/claws/self_iterator.hpp
@@ -12,11 +12,11 @@ namespace claws
       : value(std::move(value))
     {}
 
-    constexpr self_iterator() noexcept = default;
-    constexpr self_iterator(self_iterator const &) noexcept = default;
-    constexpr self_iterator(self_iterator &&) noexcept = default;
-    constexpr self_iterator &operator=(self_iterator const &) noexcept = default;
-    constexpr self_iterator &operator=(self_iterator &&) noexcept = default;
+    constexpr self_iterator() = default;
+    constexpr self_iterator(self_iterator const &) = default;
+    constexpr self_iterator(self_iterator &&) = default;
+    constexpr self_iterator &operator=(self_iterator const &) = default;
+    constexpr self_iterator &operator=(self_iterator &&) = default;
 
 #define SELF_ITERATOR_UNARY_PREFIX(OP)                                                                                                                         \
   constexpr auto &operator OP() noexcept                                                                                                                       \


### PR DESCRIPTION
Apparently works differently than expected:
https://stackoverflow.com/questions/29483120/program-with-noexcept-constructor-accepted-by-gcc-rejected-by-clang#29483269

Also fixes compilation error on clang++.