### PR TITLE
Update .travis.yml to docs 0.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,3 @@
 language: cpp
 script:
   - echo 'There are no tests (yet)'
-
-# Update doc
-after_success:
-  - |
-      if [[ "$TRAVIS_BRANCH" = master && "$TRAVIS_PULL_REQUEST" = false ]]; then
-          TRAVIS_REPO_NAME=(${TRAVIS_REPO_SLUG//\// });
-          wget https://api.raven-os.org/${TRAVIS_REPO_NAME[1]}/$RAVEN_DOCS_TOKEN
-      fi


### PR DESCRIPTION
claw's `.travis.yml` was still using `docs` 0.1 API.

I've updated it to 0.2, which means removing everything because it's now automated :p