### PR TITLE
Fix missing includes in box.hpp

### DIFF
--- a/include/claws/box.hpp
+++ b/include/claws/box.hpp
@@ -1,5 +1,8 @@
 #pragma once
 
+#include <type_traits>
+#include <utility>
+
 namespace claws
 {
   ///


### PR DESCRIPTION
- `std::move` requires including `utility`
- `std::is_class_v` requires including `type_traits`