### PR TITLE
Fix missing <iterator> include in container/vect.hpp

### DIFF
--- a/modules/container/claws/container/vect.hpp
+++ b/modules/container/claws/container/vect.hpp
@@ -4,6 +4,7 @@
 #include <cstddef>
 #include <type_traits>
 #include <utility>
+#include <iterator>
 #include <claws/algorithm/constexpr_algorithm.hpp>
 
 namespace claws


### PR DESCRIPTION
Closes: #50 